### PR TITLE
Catch that mod_authz_default has been removed in Apache 2.4

### DIFF
--- a/manifests/mod/authz_default.pp
+++ b/manifests/mod/authz_default.pp
@@ -1,4 +1,6 @@
-class apache::mod::authz_default {
+class apache::mod::authz_default(
+    $apache_version = $::apache::apache_version
+) {
   if versioncmp($apache_version, '2.4') >= 0 {
     warning('apache::mod::authz_default has been removed in Apache 2.4')
   } else {

--- a/manifests/mod/authz_default.pp
+++ b/manifests/mod/authz_default.pp
@@ -1,3 +1,7 @@
 class apache::mod::authz_default {
-  ::apache::mod { 'authz_default': }
+  if versioncmp($apache_version, '2.4') >= 0 {
+    warning('apache::mod::authz_default has been removed in Apache 2.4')
+  } else {
+    ::apache::mod { 'authz_default': }
+  }
 }


### PR DESCRIPTION
Having it in the server config will prevent the server from starting as the module file cannot be found.
